### PR TITLE
Enum items are comparable by their values (==, !=, >, >=, <, <=)

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -58,6 +58,10 @@ All `Enum` types can be compared against their values:
     assert HttpStatuses.UNAUTHORIZED == 401
     assert HttpStatuses.FORBIDDEN == 403
 
+    status_code = HttpStatuses.OK
+    assert 200 <= status_code <= 300
+
+
 All `Enum` types have by default a `display` derived from the enum identifier:
 
 .. code:: python
@@ -84,6 +88,25 @@ You can easily define your own custom display for an `Enum` item using a tuple:
     assert HttpStatuses.UNAUTHORIZED.display == 'I know your IP'
     assert HttpStatuses.FORBIDDEN.display == 'Forbidden'
 
+
+You can declare custom properties and methods:
+
+
+.. code:: python
+
+    class HttpStatuses(ChoicesEnum):
+        OK = 200, 'Everything is fine'
+        BAD_REQUEST = 400, 'You did a mistake'
+        UNAUTHORIZED = 401, 'I know your IP'
+        FORBIDDEN = 403
+
+        @property
+        def is_error(self):
+            return self >= self.BAD_REQUEST
+
+    assert HttpStatuses.OK.is_error is False
+    assert HttpStatuses.BAD_REQUEST.is_error is True
+    assert HttpStatuses.UNAUTHORIZED.is_error is True
 
 
 Example with ``Colors``:

--- a/choicesenum/enums.py
+++ b/choicesenum/enums.py
@@ -25,8 +25,9 @@ class ChoicesEnum(Enum):
     def __repr__(self):
         return "%s(%r).%s" % (self.__class__.__name__, self._value_, self._name_, )
 
-    def __eq__(self, other):
-        return self.value == getattr(other, 'value', other)
+    @staticmethod
+    def _get_value(item):
+        return getattr(item, 'value', item)
 
     def __len__(self):
         try:
@@ -36,6 +37,24 @@ class ChoicesEnum(Enum):
 
     def __hash__(self):
         return hash(self._name_)
+
+    def __lt__(self, other):
+        return self.value < self._get_value(other)
+
+    def __le__(self, other):
+        return self.value <= self._get_value(other)
+
+    def __eq__(self, other):
+        return self.value == self._get_value(other)
+
+    def __ne__(self, other):
+        return not self == other
+
+    def __gt__(self, other):
+        return self.value > self._get_value(other)
+
+    def __ge__(self, other):
+        return self.value >= self._get_value(other)
 
     def __dir__(self):
         return sorted(set(
@@ -73,6 +92,14 @@ class ChoicesEnum(Enum):
             cls (Enum): Enum class.
         """
         return [(x, x.display) for x in cls]
+
+    @classmethod
+    def values(cls):
+        """
+        Args:
+            cls (Enum): Enum class.
+        """
+        return [x.value for x in cls]
 
     @classmethod
     def options(cls):

--- a/tests/app/enums.py
+++ b/tests/app/enums.py
@@ -24,6 +24,10 @@ class HttpStatus(ChoicesEnum):
     UNAUTHORIZED = 401
     FORBIDDEN = 403
 
+    @property
+    def is_error(self):
+        return self >= self.BAD_REQUEST
+
 
 class Sizes(ChoicesEnum):
     EMPTY = None


### PR DESCRIPTION
Implements the [rich comparison methods](https://docs.python.org/3.6/reference/datamodel.html#object.__lt__).

Closes #6.

Allows use cases like this example:

``` python
    class HttpStatuses(ChoicesEnum):
        OK = 200
        BAD_REQUEST = 400
        UNAUTHORIZED = 401
        FORBIDDEN = 403

        @property
        def is_error(self):
            return self >= self.BAD_REQUEST

    status_code = HttpStatuses.OK
    assert 200 <= status_code <= 300
    assert status_code.is_error is False

    assert HttpStatuses.OK.is_error is False
    assert HttpStatuses.BAD_REQUEST.is_error is True
    assert HttpStatuses.UNAUTHORIZED.is_error is True
```