### PR TITLE
Support queries through select_related with no None value defined

### DIFF
--- a/choicesenum/django/fields.py
+++ b/choicesenum/django/fields.py
@@ -88,7 +88,16 @@ class EnumFieldMixin(object):
         return self.enum(value)
 
     def from_db_value(self, value, expression, connection, context):
-        return self.to_python(value)
+        try:
+            return self.enum(value)
+        except ValueError:
+            # We need to return None here even if the enum has no None value
+            # to support models being fetched via select_related.
+            # The row converters are run before the pk=None check in
+            # the default Django model managers.
+            if value is None:
+                return value
+            raise
 
     def get_prep_value(self, value):
         enum_value = self.to_python(value)

--- a/tests/app/models.py
+++ b/tests/app/models.py
@@ -18,3 +18,7 @@ class ColorModel(models.Model):
 class User(models.Model):
     username = models.CharField(max_length=50)
     status = EnumIntegerField(enum=UserStatus, null=True)
+
+
+class Preference(models.Model):
+    color = models.ForeignKey(ColorModel, null=True)

--- a/tests/test_django_fields.py
+++ b/tests/test_django_fields.py
@@ -251,3 +251,31 @@ def test_integer_field_should_allow_filters():
 
     instance2 = User.objects.filter(status=UserStatus.ACTIVE).first()
     assert instance.pk == instance2.pk
+
+
+@pytest.mark.django_db
+def test_handle_select_related_with_no_none_enum_value():
+    # given
+    from tests.app.models import Preference
+
+    # when
+    Preference.objects.create()
+
+    # then
+
+    objs = Preference.objects.select_related('color')
+    assert len(objs) == 1
+
+
+@pytest.mark.django_db
+def test_converts_null_to_enum_none_if_present():
+    # given
+    from tests.app.models import User, UserStatus
+
+    # when
+    User.objects.create(status=None)
+    instance = User.objects.filter(status=None).first()
+
+    # then
+
+    assert instance.status.display == UserStatus.UNDEFINED.display


### PR DESCRIPTION
When Django joins in a table with a EnumField that does not exist,
all the table columns are NULL. The SQL processing then runs the
converters (to_python et.al), and the convertion to None for the
ForeignKey field is done later in the manager.

Due to this behaviour we need to return None in our from_db_value method
even if we have no None value in our enum. The defence against null
values is then entirely up to the database to enforce.

Not ideal, but its the only way to get reasonable performance when
querying these tables.