### PR TITLE
Enum with same hash as its value

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,5 +1,6 @@
 # Byte-compiled / optimized / DLL files
 __pycache__/
+.pytest_cache/
 *.py[cod]
 *$py.class
 

--- a/HISTORY.rst
+++ b/HISTORY.rst
@@ -2,6 +2,12 @@
 History
 =======
 
+0.3.0 (2018-06-22)
+------------------
+
+* Official Django 2.0 support (0.2.2 just works fine too).
+* ``ChoicesEnum`` sharing the same hash() as his value. Can be used to retrieve/restore items in dicts (`d[enum] == d[enum.value]`).
+
 0.2.2 (2017-12-01)
 ------------------
 

--- a/README.rst
+++ b/README.rst
@@ -164,6 +164,20 @@ The enum item can be used whenever the value is needed:
     assert u'Currrent color is {c} ({c.display})'.format(c=color) ==\
            u'Currrent color is #f00 (Vermelho)'
 
+Even in dicts and sets, as it shares the same `hash()` from his value:
+
+.. code:: python
+
+    d = {
+        HttpStatuses.OK.value: "nice",
+        HttpStatuses.BAD_REQUEST.value: "bad",
+        401: "Don't do this",
+    }
+    assert d[HttpStatuses.OK] == "nice"
+    assert d[HttpStatuses.OK.value] == "nice"
+    assert d[HttpStatuses.OK] == d[HttpStatuses.OK.value]
+    assert d[HttpStatuses.UNAUTHORIZED] == d[401]
+
 
 Usage with the custom Django fields:
 

--- a/choicesenum/enums.py
+++ b/choicesenum/enums.py
@@ -36,7 +36,7 @@ class ChoicesEnum(Enum):
             return 1
 
     def __hash__(self):
-        return hash(self._name_)
+        return hash(self.value)
 
     def __lt__(self, other):
         return self.value < self._get_value(other)

--- a/requirements_dev.txt
+++ b/requirements_dev.txt
@@ -1,15 +1,15 @@
 # test
 -r requirements_test.txt
-pytest-django==3.1.2
-Django==2.0.3
+pytest-django==3.3.2
+Django==2.0.6
 tox==3.0.0
 
 # docs
-Sphinx==1.7.1
+Sphinx==1.7.5
 
 # build / deploy
 PyYAML==3.12
-wheel==0.30.0
+wheel==0.31.1
 bumpversion==0.5.3
-cryptography==2.1.4
+cryptography==2.2.2
 pip==10.0.1

--- a/requirements_test.txt
+++ b/requirements_test.txt
@@ -1,6 +1,6 @@
 # test
-pytest==3.4.1
+pytest==3.6.2
 pytest-cov==2.5.1
-pytest-flake8==0.9.1
-pytest-watch==4.1.0
+pytest-flake8==1.0.1
+pytest-watch==4.2.0
 pytest-sugar==0.9.1

--- a/tests/test_choicesenum.py
+++ b/tests/test_choicesenum.py
@@ -243,3 +243,18 @@ def test_custom_properties(request, enum_fixture, attr, property, expected):
     prop_value = getattr(enum_item, property)
 
     assert prop_value == expected
+
+
+def test_should_be_used_as_replacement_as_key_on_dics(http_statuses):
+    # given
+    d = {
+        http_statuses.OK: "nice",
+        http_statuses.BAD_REQUEST: "bad",
+        401: "Don't do this",
+    }
+
+    # then
+    assert d[http_statuses.OK] == "nice"
+    assert d[http_statuses.OK.value] == "nice"
+    assert d[http_statuses.OK] == d[http_statuses.OK.value]
+    assert d[http_statuses.UNAUTHORIZED] == d[401]

--- a/tests/test_django_fields.py
+++ b/tests/test_django_fields.py
@@ -277,5 +277,23 @@ def test_converts_null_to_enum_none_if_present():
     instance = User.objects.filter(status=None).first()
 
     # then
-
     assert instance.status.display == UserStatus.UNDEFINED.display
+
+
+@pytest.mark.django_db
+def test_raise_error_when_value_is_not_an_possible_choice():
+    # given
+    from tests.app.models import User
+    from django.db import connection
+    cur = connection.cursor()
+    try:
+        cur.execute("insert into app_user values(1, 'bla', 5)")
+    finally:
+        cur.close()
+
+    # when
+    with pytest.raises(ValueError) as excinfo:
+        User.objects.first()
+
+    # then
+    assert str(excinfo.value) == '5 is not a valid UserStatus'


### PR DESCRIPTION
Allows the `ChoicesEnum` to retrieve/store values from dicts/sets that already exists in your system, so you can start using `ChoicesEnum` even if you still uses other constants to represent the enum's value.  

`ChoicesEnum` and it's value now shares the same hash, as the result of the hash function now is equal to the enum value and the enum itself: `hash(ChoicesEnum.item) == hash(ChoicesEnum.item.value)`.