### PR TITLE
Implement optimistic casting of inner types for int() and float()

### DIFF
--- a/choicesenum/enums.py
+++ b/choicesenum/enums.py
@@ -22,6 +22,12 @@ class ChoicesEnum(Enum):
     def __str__(self):
         return str(self.value)
 
+    def __int__(self):
+        return int(self.value)
+
+    def __float__(self):
+        return float(self.value)
+
     def __repr__(self):
         return "%s(%r).%s" % (self.__class__.__name__, self._value_, self._name_, )
 

--- a/tests/test_choicesenum.py
+++ b/tests/test_choicesenum.py
@@ -85,6 +85,15 @@ def test_in_format_python2(colors):
     assert '{!r}'.format(colors.RED) == "Color(u'#f00').RED"
 
 
+@pytest.mark.parametrize('cast', (str, int, float))
+def test_casting(http_statuses, cast):
+    result = cast(http_statuses.OK)
+    expected = cast(http_statuses.OK.value)
+
+    assert result == expected
+    assert type(result) == type(expected)
+
+
 def test_should_proxy_len_calls(colors):
     assert len(colors.RED) == len(colors.RED.value) == len('#f00') == 4
 


### PR DESCRIPTION
Try to cast the inner value when someones tries to cast an enum with `int()` or `float()`.