### PR TITLE
feat(patches) Optional stdlib patch to automagic json serialization support

### DIFF
--- a/HISTORY.rst
+++ b/HISTORY.rst
@@ -2,6 +2,13 @@
 History
 =======
 
+0.3.1 (2018-07-13)
+------------------
+
+* Optimistic casting of inner types (thanks @gabisurita).
+* Optional stdlib patch to automagic json serialization support.
+
+
 0.3.0 (2018-06-22)
 ------------------
 

--- a/README.rst
+++ b/README.rst
@@ -19,6 +19,7 @@ Python's Enum with extra powers to play nice with labels and choices fields.
 * Free software: BSD license
 * Documentation: https://python-choicesenum.readthedocs.io.
 
+------------
 Installation
 ------------
 
@@ -26,7 +27,7 @@ Install ``choicesenum`` using pip::
 
     $ pip install choicesenum
 
-
+--------
 Features
 --------
 
@@ -36,6 +37,7 @@ Features
 * Support (tested) for Python 2.7, 3.4, 3.5 and 3.6.
 * Support (tested) for Django 1.6.1 (with south), 1.7, 1.8, 1.9, 1.10, 1.11 and 2.0.
 
+--------------
 Usage examples
 --------------
 
@@ -49,6 +51,21 @@ Example with ``HttpStatuses``:
         UNAUTHORIZED = 401
         FORBIDDEN = 403
 
+Example with ``Colors``:
+
+.. code:: python
+
+    from choicesenum import ChoicesEnum
+
+    class Colors(ChoicesEnum):
+        RED = '#f00', 'Vermelho'
+        GREEN = '#0f0', 'Verde'
+        BLUE = '#00f', 'Azul'
+
+
+Comparisson
+-----------
+
 All `Enum` types can be compared against their values:
 
 .. code:: python
@@ -61,6 +78,13 @@ All `Enum` types can be compared against their values:
     status_code = HttpStatuses.OK
     assert 200 <= status_code <= 300
 
+    assert Colors.RED == '#f00'
+    assert Colors.GREEN == '#0f0'
+    assert Colors.BLUE == '#00f'
+
+
+Label for free
+--------------
 
 All `Enum` types have by default a `display` derived from the enum identifier:
 
@@ -89,8 +113,44 @@ You can easily define your own custom display for an `Enum` item using a tuple:
     assert HttpStatuses.FORBIDDEN.display == 'Forbidden'
 
 
-You can declare custom properties and methods:
+Dynamic properties
+------------------
 
+For each enum item, a dynamic property ``is_<enum_item>`` is generated to allow
+quick boolean checks:
+
+.. code:: python
+
+    color = Colors.RED
+    assert color.is_red
+    assert not color.is_blue
+    assert not color.is_green
+
+This feature is usefull to avoid comparing a received enum value against a know enum item.
+
+For example, you can replace code like this:
+
+.. code:: python
+
+    # status = HttpStatuses.BAD_REQUEST
+
+    def check_status(status):
+        if status == HttpStatuses.OK:
+            print("Ok!")
+
+To this:
+
+.. code:: python
+
+    def check_status(status):
+        if status.is_ok:
+            print("Ok!")
+
+
+Custom methods and properties
+-----------------------------
+
+You can declare custom properties and methods:
 
 .. code:: python
 
@@ -108,54 +168,68 @@ You can declare custom properties and methods:
     assert HttpStatuses.BAD_REQUEST.is_error is True
     assert HttpStatuses.UNAUTHORIZED.is_error is True
 
+Iteration
+---------
 
-Example with ``Colors``:
+The enum type is iterable:
+
+.. code:: python
+
+    >>> for color in Colors:
+    ...     print(repr(color))
+    Color('#f00').RED
+    Color('#0f0').GREEN
+    Color('#00f').BLUE
+
+
+Order is guaranteed only for py3.4+. For fixed order in py2.7, you
+can implement a magic attribute ``_order_``:
 
 .. code:: python
 
     from choicesenum import ChoicesEnum
 
     class Colors(ChoicesEnum):
-        # For fixed order in  py2.7, py3.4+ are ordered by default
         _order_ = 'RED GREEN BLUE'
 
         RED = '#f00', 'Vermelho'
         GREEN = '#0f0', 'Verde'
         BLUE = '#00f', 'Azul'
 
-    assert Colors.RED == '#f00'
-    assert Colors.GREEN == '#0f0'
-    assert Colors.BLUE == '#00f'
-
-    assert Colors.RED.display == 'Vermelho'
-    assert Colors.GREEN.display == 'Verde'
-    assert Colors.BLUE.display == 'Azul'
-
+Choices
+-------
 
 Use ``.choices()`` method to receive a list of tuples ``(item, display)``:
 
 .. code:: python
 
-    # choices
     assert list(Colors.choices()) == [
         ('#f00', 'Vermelho'),
         ('#0f0', 'Verde'),
         ('#00f', 'Azul'),
     ]
 
+Values
+-------
 
-For each enum item, a dynamic property ``is_<enum_item>`` is generated to allow
-quick boolean checks:
+Use ``.values()`` method to receive a list of the inner values:
 
 .. code:: python
 
-    color = Colors.RED
-    assert color.is_red
-    assert not color.is_blue
-    assert not color.is_green
+    assert Colors.values() == ['#f00', '#0f0', '#00f', ]
 
-    if color.is_red:
-        print 'Is red!'
+Options
+-------
+
+Even if a ``ChoicesEnum`` class is an iterator by itself, you can use ``.options()`` to convert the enum itens to a list:
+
+.. code:: python
+
+    assert Colors.options() == [Colors.RED, Colors.GREEN, Colors.BLUE]
+
+
+Compatibility
+-------------
 
 The enum item can be used whenever the value is needed:
 
@@ -178,6 +252,20 @@ Even in dicts and sets, as it shares the same `hash()` from his value:
     assert d[HttpStatuses.OK] == d[HttpStatuses.OK.value]
     assert d[HttpStatuses.UNAUTHORIZED] == d[401]
 
+There's also optimistic casting of inner types:
+
+.. code:: python
+
+    assert int(HttpStatuses.OK) == 200
+    assert float(HttpStatuses.OK) == 200.0
+    assert str(HttpStatuses.BAD_REQUEST) == "400"
+
+------
+Django
+------
+
+Fields
+------
 
 Usage with the custom Django fields:
 
@@ -235,6 +323,11 @@ so if your field allow `null`, your enum should also:
     # again...
     instance.status = None
     assert instance.status.is_undefined is True
+
+
+--------
+Graphene
+--------
 
 Usage with Graphene_ Enums:
 

--- a/choicesenum/enums.py
+++ b/choicesenum/enums.py
@@ -70,6 +70,24 @@ class ChoicesEnum(Enum):
             list(self._get_dynamic_property_names())
         ))
 
+    def __json__(self):
+        """
+        If you want json serialization, you have at least two options:
+            1. Patch the default serializer.
+            2. Write a custom JSONEncoder.
+
+        ChoicesEnum comes with a handy patch funtion, you need to add this
+        code, to somewhere at the top of everything to automagically add
+        json serialization capabilities:
+
+            from choicesenum.patches import patch_json
+            patch_json()
+
+        Note: Eventually `__json__` will be added to the stdlib, see
+            https://bugs.python.org/issue27362
+        """
+        return self.value
+
     @property
     def display(self):
         return self._display_ if self._display_ is not None else\

--- a/choicesenum/patches.py
+++ b/choicesenum/patches.py
@@ -1,0 +1,15 @@
+
+
+def patch_json():
+    """
+    Patch json default encoder to globally try to find and call a ``__json__``
+    method inside classes before raising "TypeError: Object of type 'X' is not
+    JSON serializable"
+    """
+    from json import JSONEncoder
+
+    def _default(self, obj):
+        return getattr(obj.__class__, "__json__", _default.default)(obj)
+
+    _default.default = JSONEncoder().default
+    JSONEncoder.default = _default

--- a/tests/test_choicesenum.py
+++ b/tests/test_choicesenum.py
@@ -267,3 +267,24 @@ def test_should_be_used_as_replacement_as_key_on_dics(http_statuses):
     assert d[http_statuses.BAD_REQUEST.value] == "using enum"
     assert d[http_statuses.OK] == d[http_statuses.OK.value]
     assert d[http_statuses.UNAUTHORIZED] == d[401]
+
+
+@pytest.mark.parametrize('enum_fixture, expected_json', [
+    ('http_statuses', '{"enum_values": [200, 400, 401, 403]}'),
+])
+def test_should_be_json_serializable(request, enum_fixture, expected_json):
+    import json
+    from choicesenum.patches import patch_json
+    # given
+    patch_json()  # patching the default encoder
+
+    enum = request.getfixturevalue(enum_fixture)
+    data = {
+        "enum_values": enum.options(),
+    }
+
+    # when
+    result = json.dumps(data)
+
+    # then
+    assert result == expected_json


### PR DESCRIPTION
If you want json serialization, you have at least two options:
1. Patch the default serializer.
2. Write a custom JSONEncoder.

ChoicesEnum comes with a handy patch funtion, you need to add this
code, to somewhere at the top of everything to automagically add
json serialization capabilities:

``` python
    from choicesenum.patches import patch_json
    patch_json()
```

Note: Eventually `__json__` will be added to the stdlib, see https://bugs.python.org/issue27362