### PR TITLE
Support Postgres Array functions and queries

### DIFF
--- a/choicesenum/django/fields.py
+++ b/choicesenum/django/fields.py
@@ -97,6 +97,14 @@ class EnumFieldMixin(object):
             # the default Django model managers.
             if value is None:
                 return value
+
+            # For certain operations on Postgres ArrayFields and Array
+            # aggregation, we need to handle list values
+            if type(value) == list:
+                return list(filter(None, [
+                    self.from_db_value(x, expression, connection, context)
+                    for x in value
+                ]))
             raise
 
     def get_prep_value(self, value):

--- a/tests/test_django_fields.py
+++ b/tests/test_django_fields.py
@@ -297,3 +297,21 @@ def test_raise_error_when_value_is_not_an_possible_choice():
 
     # then
     assert str(excinfo.value) == '5 is not a valid UserStatus'
+
+
+@pytest.mark.skipif(
+    django.VERSION[:2] < (1, 7),
+    reason="requires Django 1.7+ for accessing Model.attribute.field")
+def test_converts_list_aggregations():
+    # given
+    from tests.app.models import ColorModel, Color
+
+    # when
+    db_return_value = [Color.RED.value, Color.GREEN.value, None]
+
+    # then
+    objs = ColorModel.color.field.from_db_value(db_return_value, None, None, None)
+
+    assert len(objs) == 2
+    assert objs[0] == Color.RED
+    assert objs[1] == Color.GREEN


### PR DESCRIPTION
Some Postgres functions may return a list of values from the db,
for instance `ArrayAgg`. This commit implements support for using
those on EnumFields.

Since this is only applicable for Postgres database, a test would 
not work with the Sqlite database, so the test is a tad hacky, sorry.

Example with testmodels to test with Postgres yourself:
```
from django.contrib.postgres.aggregates import ArrayAgg

green = ColorModel.objects.create(color=Color.GREEN)
red = ColorModel.objects.create(color=Color.RED)
Preference.objects.create(color=red)
Preference.objects.create()

# Using F instead of ArrayAgg would make more sense with the test models,
# but if ColorModel had a FK to Preference, this would be more applicable
Preference.objects.all().annotate(colors=ArrayAgg('color__color'))
```