### PR TITLE
Support queryset defer()

### DIFF
--- a/choicesenum/django/compat.py
+++ b/choicesenum/django/compat.py
@@ -1,20 +1,25 @@
 # coding: utf-8
 from __future__ import absolute_import, unicode_literals
 
+import django
+from django.db.models.query_utils import DeferredAttribute
 
-class Creator(object):
+
+class Creator(DeferredAttribute):
     """
     Django 1.10 removed the SubfieldBase. We have backported the to_python
     behaviour for <=1.9 code by copying Creator from Django's 1.8.x branch:
       ``django.db.models.fields.subclassing``
     """
-    def __init__(self, field):
-        self.field = field
+    if django.VERSION < (2, 1):
+        def __init__(self, field, model):
+            self.field = field
+            super(Creator, self).__init__(field.attname, model)
 
-    def __get__(self, obj, type=None):
-        if obj is None:  # pragma: no cover
-            return self
-        return obj.__dict__[self.field.name]
+    else:
+        def __init__(self, field, model):
+            self.field = field
+            super(Creator, self).__init__(field.attname)
 
     def __set__(self, obj, value):
-        obj.__dict__[self.field.name] = self.field.to_python(value)
+        obj.__dict__[self.field_name] = self.field.to_python(value)

--- a/choicesenum/django/fields.py
+++ b/choicesenum/django/fields.py
@@ -82,7 +82,7 @@ class EnumFieldMixin(object):
         # Retain to_python behaviour for < Django 1.8 with removal
         # of SubfieldBase
         super(EnumFieldMixin, self).contribute_to_class(cls, name)
-        setattr(cls, name, Creator(self))
+        setattr(cls, name, Creator(self, cls))
 
     def to_python(self, value):
         return self.enum(value)


### PR DESCRIPTION
This adds support for deferring an enum field. It's compatible with all Django/Python versions but one test gets broken for old Django versions so I added a `skipIf`.
Creator now inherits DeferredAttribute, which is what Django's base `Field` class uses to support this.