### PR TITLE
Adds a get method able to return a default value

### DIFF
--- a/AUTHORS.rst
+++ b/AUTHORS.rst
@@ -12,6 +12,7 @@ Contributors
 
 * Kristian Klette <klette@klette.us>
 * Gabriela Surita <gabsurita@gmail.com>
+* Leandro Gomes <leandrogs99@gmail.com>
 
 
 Tools

--- a/README.rst
+++ b/README.rst
@@ -227,6 +227,17 @@ Even if a ``ChoicesEnum`` class is an iterator by itself, you can use ``.options
 
     assert Colors.options() == [Colors.RED, Colors.GREEN, Colors.BLUE]
 
+A "dict like" get
+-------------
+
+Use ``.get(value, default=None)`` method to receive ``default`` if ``value`` is not an item of enum:
+
+.. code:: python
+
+    Colors.get(Colors.RED) == Colors.RED
+    Colors.get('#f00') == Colors.RED
+    Colors.get('undefined_color') is None
+    Colors.get('undefined_color', Colors.RED) == Colors.RED
 
 Compatibility
 -------------

--- a/choicesenum/enums.py
+++ b/choicesenum/enums.py
@@ -136,5 +136,20 @@ class ChoicesEnum(Enum):
         return list(cls)
 
     @classmethod
+    def get(cls, value, default=None):
+        """
+        Dict `.get()` like to return a default value.
+
+        Args:
+            cls (Enum): Enum class.
+            value: Value to get inside Enum.
+            default: Value to return in case of error. Default is None.
+        """
+        try:
+            return cls(value)
+        except Exception:
+            return default
+
+    @classmethod
     def _import_path(cls):
         return '{}.{}'.format(cls.__module__, cls.__name__)

--- a/tests/test_choicesenum.py
+++ b/tests/test_choicesenum.py
@@ -288,3 +288,10 @@ def test_should_be_json_serializable(request, enum_fixture, expected_json):
 
     # then
     assert result == expected_json
+
+
+def test_should_return_default_value(colors):
+    assert colors.get(colors.RED) == colors.RED
+    assert colors.get('#f00') == colors.RED
+    assert colors.get('undefined_color') is None
+    assert colors.get('undefined_color', colors.RED) == colors.RED


### PR DESCRIPTION

## Adds a "dict like" get

Use `.get(value, default=None)` method to receive `default` if `value` is not an item of enum:

``` python
assert Colors.get(Colors.RED) == Colors.RED
assert Colors.get('#f00') == Colors.RED
assert Colors.get('undefined_color') is None
assert Colors.get('undefined_color', Colors.RED) == Colors.RED
```