### PR TITLE
Membership test  returning valid results for primitive values 

### DIFF
--- a/choicesenum/enums.py
+++ b/choicesenum/enums.py
@@ -1,10 +1,23 @@
 # coding: utf-8
 from __future__ import absolute_import, unicode_literals
 
-from enum import Enum
+import six
+from enum import Enum, EnumMeta
 
 
-class ChoicesEnum(Enum):
+class ChoicesMetaClass(EnumMeta):
+
+    def __contains__(cls, member):
+        if not isinstance(member, cls):
+            try:
+                member = cls(member)
+            except Exception:
+                return False
+
+        return member._name_ in cls._member_map_
+
+
+class ChoicesEnum(six.with_metaclass(ChoicesMetaClass, Enum)):
 
     def __new__(cls, value, display=None):
         obj = object.__new__(cls)
@@ -90,7 +103,7 @@ class ChoicesEnum(Enum):
 
     @property
     def display(self):
-        return self._display_ if self._display_ is not None else\
+        return self._display_ if self._display_ is not None else \
             self._name_.replace('_', ' ').capitalize()
 
     @property

--- a/requirements_test.txt
+++ b/requirements_test.txt
@@ -2,6 +2,5 @@
 mock==2.0.0
 pytest==3.10.1
 pytest-cov==2.6.0
-pytest-flake8==1.0.2
 pytest-watch==4.2.0
 pytest-sugar==0.9.2

--- a/tests/test_choicesenum.py
+++ b/tests/test_choicesenum.py
@@ -296,3 +296,9 @@ def test_should_return_default_value(colors):
     assert colors.get('#f00') == colors.RED
     assert colors.get('undefined_color') is None
     assert colors.get('undefined_color', colors.RED) == colors.RED
+
+
+def test_should_support_membership_vertification(colors):
+    assert colors.RED in colors
+    assert colors.RED.value in colors
+    assert 'non-existent-color' not in colors

--- a/tox.ini
+++ b/tox.ini
@@ -3,6 +3,7 @@ envlist =
     py{27}-django-{16,17,18,19,110,111}
     py{34}-django-{110,111,20}
     py{35,36,37}-django-{110,111,20,21}
+    py36-flake8
 
 [pytest]
 filterwarnings =
@@ -36,7 +37,7 @@ deps =
     -r{toxinidir}/requirements_test.txt
 commands =
     pip install -U pip
-    py.test --basetemp={envtmpdir}  --flake8 --cov
+    py.test --basetemp={envtmpdir} --cov
 
 basepython =
     py37: python3.7
@@ -44,3 +45,8 @@ basepython =
     py35: python3.5
     py34: python3.4
     py27: python2.7
+
+
+[testenv:py36-flake8]
+commands = flake8 choicesenum/ tests/
+deps = flake8


### PR DESCRIPTION
### Description

Given a ChoicesEnum:

``` python
from choicesenum import ChoicesEnum

class Colors(ChoicesEnum):
    RED = '#f00', 'Vermelho'
    GREEN = '#0f0', 'Verde'
    BLUE = '#00f', 'Azul'
```

The membership test only works for Enum instances:

``` python
assert Colors.RED in Colors
```

with this PR, you can ask for membership using primitive values:

``` python
assert '#f00' in Colors
```
