### PR TITLE
fix(migrations) Fix migrations with default value for Django 1.7+

### DIFF
--- a/choicesenum/django/fields.py
+++ b/choicesenum/django/fields.py
@@ -113,6 +113,10 @@ class EnumFieldMixin(object):
 
     def deconstruct(self):
         name, path, args, kwargs = super(EnumFieldMixin, self).deconstruct()
+
+        if 'default' in kwargs and self.default:
+            kwargs['default'] = self.to_python(self.default).value
+
         if self.enum:
             kwargs["enum"] = self.enum
             if 'choices' in kwargs:  # pragma: no cover

--- a/tests/test_django_fields.py
+++ b/tests/test_django_fields.py
@@ -165,7 +165,7 @@ def test_migrations_deconstruct_support(field_cls, enum_for_field_cls):
         [],
         {
             'enum': enum_for_field_cls,
-            'default': default_enum,
+            'default': default_enum.value,
         },
     )
 


### PR DESCRIPTION
Migrations with default values are generating exceptions on Django1.7+:

```
ValueError: Cannot serialize: <EnumClass.EnumItem>
There are some values Django cannot serialize into migration files.
For more, see https://docs.djangoproject.com/en/dev/topics/migrations/#migration-serializing
E
```

This PR fix this issue returning the default value as a primitive (`.value`) instead of the enum item.