### PR TITLE
Add support for Django 3.0

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -3,6 +3,8 @@
 
 language: python
 python:
+  - 3.8
+  - 3.7
   - 3.6
   - 3.5
   - 3.4

--- a/choicesenum/django/compat.py
+++ b/choicesenum/django/compat.py
@@ -15,8 +15,13 @@ class Creator(DeferredAttribute):
         self.field = field
         if django.VERSION < (2, 1):  # pragma: no cover (Django < 2.1 compat)
             super(Creator, self).__init__(field.attname, model)
-        else:  # pragma: no cover
+        elif django.VERSION < (3, 0):
             super(Creator, self).__init__(field.attname)
+        else:  # pragma: no cover
+            super(Creator, self).__init__(field)
 
     def __set__(self, obj, value):
-        obj.__dict__[self.field_name] = self.field.to_python(value)
+        if hasattr(self, 'field_name'):
+            obj.__dict__[self.field_name] = self.field.to_python(value)
+        else:
+            obj.__dict__[self.field.attname] = self.field.to_python(value)

--- a/choicesenum/django/fields.py
+++ b/choicesenum/django/fields.py
@@ -5,11 +5,12 @@ from __future__ import absolute_import, unicode_literals
 from django.core import checks
 from django.db import models
 from django.utils.translation import ugettext_lazy as _
-from django.utils import six
 try:
     from django.utils.module_loading import import_string
 except ImportError:  # pragma: no cover, Django 1.6 compat
     from django.utils.module_loading import import_by_path as import_string
+
+import six
 
 from .compat import Creator
 from ..enums import ChoicesEnum

--- a/setup.py
+++ b/setup.py
@@ -13,6 +13,7 @@ with open('HISTORY.rst') as history_file:
 
 requirements = [
     'enum34;python_version<"3.4"',
+    'six',
 ]
 
 setup_requirements = []

--- a/tox.ini
+++ b/tox.ini
@@ -2,7 +2,8 @@
 envlist =
     py{27}-django-{19,110,111}
     py{34}-django-{110,111,20}
-    py{35,36,37}-django-{110,111,20,21}
+    py{35,36,37,38}-django-{110,111,20,21,22}
+    py{36,37,38}-django-{30}
     py36-flake8
 
 [pytest]
@@ -11,6 +12,7 @@ filterwarnings =
 
 [travis]
 python =
+    3.8: py38
     3.7: py37
     3.6: py36
     3.5: py35
@@ -28,11 +30,14 @@ deps =
     django-111: Django>=1.11,<1.12
     django-20: Django>=2.0,<2.1
     django-21: Django>=2.1,<2.2
+    django-22: Django>=2.2,<2.3
+    django-30: Django>=3.0,<3.1
 commands =
     pip install -U pip
     py.test --basetemp={envtmpdir} --cov
 
 basepython =
+    py38: python3.8
     py37: python3.7
     py36: python3.6
     py35: python3.5


### PR DESCRIPTION
* Add six as a dependency
* Fix `DeferredAttribute` initialization for Django 3.0
* Add Python 3.8 to the test matrix
* Add Django 3.0 to the test matrix