### PR TITLE
fix: Fix issue when using Django EnumIntegerField on Admin

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -7,7 +7,6 @@ python:
   - 3.7
   - 3.6
   - 3.5
-  - 3.4
   - 2.7
 
 # command to install dependencies, e.g. pip install -r requirements.txt --use-mirrors

--- a/HISTORY.rst
+++ b/HISTORY.rst
@@ -7,6 +7,7 @@ History
 
 * Add support Django 3.0 (tks @klette).
 * Drop support for Python 3.4.
+* Fix issue when using Django EnumIntegerField on Admin.
 
 
 0.6.0 (2019-09-05)
@@ -14,7 +15,6 @@ History
 
 * Adding schematics contrib type ChoicesEnumType.
 * Drop support for Django 1.6, 1.7, 1.8.
-
 
 
 0.5.3 (2019-02-06)

--- a/choicesenum/django/fields.py
+++ b/choicesenum/django/fields.py
@@ -86,7 +86,10 @@ class EnumFieldMixin(object):
         setattr(cls, name, Creator(self, cls))
 
     def to_python(self, value):
-        return self.enum(value)
+        if isinstance(value, self.enum):
+            return value
+        cleaned_value = super(EnumFieldMixin, self).to_python(value)
+        return self.enum(cleaned_value)
 
     def from_db_value(self, value, *args, **kwargs):
         try:

--- a/tests/test_django_fields.py
+++ b/tests/test_django_fields.py
@@ -242,6 +242,17 @@ def test_integer_field_should_allow_filters():
     assert instance.pk == instance2.pk
 
 
+def test_field_to_python_should_allow_inherited_conversion():
+    # given
+    from tests.app.models import User
+
+    # when
+    user_status = User._meta.get_field('status').to_python('1')
+
+    # then
+    assert user_status.is_pending
+
+
 @pytest.mark.django_db
 def test_handle_select_related_with_no_none_enum_value():
     # given


### PR DESCRIPTION

### Fix issue when using Django EnumIntegerField on Admin

Admin receives the value as string, that must be converted to integer before converting to Enum.

The solution was to clean the value calling the `super().to_python(value)` before trying to convert to Enum.